### PR TITLE
Sugar Calendar hide events from calendar view

### DIFF
--- a/modules/sugar-calendar.php
+++ b/modules/sugar-calendar.php
@@ -26,7 +26,7 @@ function pmpro_events_sugar_calendar_has_membership_access( $hasaccess, $post, $
 add_filter( 'pmpro_has_membership_access_filter', 'pmpro_events_sugar_calendar_has_membership_access', 10, 4 );
 
 /**
- * Removes restricted events from calendar view if filtering archives set inside Paid Memberships Pro.
+ * Removes restricted events from search and archives pages if filtering archives set inside Paid Memberships Pro.
  * @since 1.0
  * Filters on https://www.paidmembershipspro.com/hook/pmpro_search_filter_post_types/
  */
@@ -41,3 +41,22 @@ function pmpro_events_sugar_calendar_filter_archives( $post_types ) {
 	return $post_types;
 }
 add_filter( 'pmpro_search_filter_post_types', 'pmpro_events_sugar_calendar_filter_archives', 10, 1 );
+
+/**
+ *  Removes restricted events from Calendar View if the user doesn't have access to an event and filtering
+ * @since 1.0
+ * 
+ */
+function pmpro_events_sugar_calendar_filter_calendar_events( $link, $event, $size ) {
+	
+	$filterqueries = pmpro_getOption( "filterqueries" );
+
+	$hide_events = apply_filters( 'pmpro_events_sugar_calendar_filter_calendar_events', true );
+
+	if ( ! pmpro_has_membership_access( $event ) && ! empty( $filterqueries ) && $hide_events ) {
+		$link = NULL;
+	}
+	
+	return $link;
+}
+add_filter( 'sc_event_calendar_link', 'pmpro_events_sugar_calendar_filter_calendar_events', 10, 3 );


### PR DESCRIPTION
Enhancement: Hide events from Calendar view.

Filter added "pmpro_events_sugar_calendar_filter_calendar_events". This will help if user's have this setting enabled in the advanced settings but don't want to filter these events in the calendar view.