### PR TITLE
Enhancement: Admin notice on activation

### DIFF
--- a/pmpro-events.php
+++ b/pmpro-events.php
@@ -8,6 +8,8 @@ Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com
 */
 
+define( 'PMPRO_EVENTS_BASENAME', plugin_basename( __FILE__ ) );
+
 function pmpro_events_plugin_init() {
 	//Load module based on active events plugin
 	$path = dirname( __FILE__ );
@@ -34,15 +36,59 @@ function pmpro_events_plugin_init() {
 }
 add_action( 'plugins_loaded', 'pmpro_events_plugin_init' );
 
+/**
+ * Adjusts the word content with "event" if it's an event.
+ * @since 1.0
+ */
 function pmpro_events_pmpro_text_filter( $text ) {
 	global $post;
-	if( is_singular( array( 'event' ) ) ) {
+
+	$event_slugs = apply_filters( 'pmpro_events_supports_event_slug', array( 'event' ) );
+
+	if( is_singular( $event_slugs ) ) {
 		$text = str_replace( 'content', 'event', $text );
 	}
 	return $text;
 }
 add_filter( 'pmpro_non_member_text_filter', 'pmpro_events_pmpro_text_filter' );
 add_filter( 'pmpro_not_logged_in_text_filter', 'pmpro_events_pmpro_text_filter' );
+
+/**
+ * Runs only when the plugin is activated.
+ * @since 1.0
+ */
+function pmpro_events_activation_hook() {
+	// Create transient data.
+	set_transient( 'pmpro-events-admin-notice', true, 5 );
+}
+register_activation_hook( PMPRO_EVENTS_BASENAME, 'pmpro_events_activation_hook' );
+
+/**
+ * Show a notice on activation.
+ * @since 1.0
+ */
+function pmpro_events_activation_admin_notice() {
+	// Check transient, if available display notice.
+	if ( get_transient( 'pmpro-events-admin-notice' ) ) {
+
+		if (  ! defined( 'EM_VERSION' ) && ! class_exists( 'Tribe__Events__Main' ) && ! defined( 'AI1EC_PATH' ) && ! class_exists( 'Sugar_Calendar\\Plugin' ) ) {
+		?>
+			<div class="notice notice-warning is-dismissible">
+			<p><?php printf( __( "Thank you for activating the Events Add On for Paid Memberships Pro. Unfortunately it seems we weren't able to find any supported events plugin. <a href='%s' target='_blank'>For more information click here.</a>", 'pmpro-events' ), "https://paidmembershipspro.com" ); ?></p>
+		</div>
+		<?php
+		}else{
+		?>
+		<div class="updated notice is-dismissible">
+			<p><?php printf( __( 'Thank you for activating the Events Add On for Paid Memberships Pro. To get started, edit an event and look for the "Require Membership" box in the sidebar. <a href="%s">View more documentation here.</a>', 'pmpro-events' ), "https://paidmembershipspro.com" ); ?></p>
+		</div>
+		<?php
+		}
+	// Delete transient, only display this notice once.
+	delete_transient( 'pmpro-events-admin-notice' );
+	}
+}
+add_action( 'admin_notices', 'pmpro_events_activation_admin_notice' );
 
 /*
 Function to add links to the plugin row meta
@@ -53,6 +99,7 @@ function pmpro_events_plugin_row_meta($links, $file) {
 			'<a href="' . esc_url('https://www.paidmembershipspro.com/add-ons/pmpro-events/')  . '" title="' . esc_attr( __( 'View Documentation', 'pmpro' ) ) . '">' . __( 'Docs', 'pmpro' ) . '</a>',			
 			'<a href="' . esc_url('https://www.paidmembershipspro.com/support/') . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro' ) ) . '">' . __( 'Support', 'pmpro' ) . '</a>',
 		);
+
 		$links = array_merge($links, $new_links);
 	}
 	return $links;


### PR DESCRIPTION
* Enhancement: Added in a notice on plugin activation. TODO: Update URL in admin notice.

* Filter: 'pmpro_events_supports_event_slug' allows modules to add their CPT slug to allow the content filter to target their specific post types and replace "content" with "event" in the non-member text message.