### PR TITLE
WP.org ready

### DIFF
--- a/modules/all-in-one-event-calendar.php
+++ b/modules/all-in-one-event-calendar.php
@@ -18,7 +18,7 @@ function pmpro_events_ai1ec_remove_event_meta( $r, $event ) {
 	$event_id = get_the_ID();
 
 	if ( ! pmpro_has_membership_access( $event_id ) && ! empty( $r ) ){
-		$r = __('This information is restricted to members only.', 'pmpro-events' );
+		$r = __( 'This content is for members only.', 'pmpro-events' );
 	}
 
 	return $r;
@@ -80,7 +80,7 @@ function pmpro_events_ai1ec_requires_membership_columns_content( $column_name, $
 			}
 		}
 		if ( ! empty( $protected_levels ) ) {
-			echo implode( ', ', $protected_levels);
+			echo wp_kses_post( implode( ', ', $protected_levels) );
 		} else {
 			echo '&mdash;';
 		}

--- a/modules/events-manager.php
+++ b/modules/events-manager.php
@@ -71,7 +71,7 @@ function pmpro_events_events_manager_em_event_output( $event_string, $post, $for
 		$pmpro_content_message_post = '</div>';
 		$content = '';
 		$sr_search = array("!!levels!!", "!!referrer!!");
-		$sr_replace = array(pmpro_implodeToEnglish($post_membership_levels_names), urlencode(site_url($_SERVER['REQUEST_URI'])));
+		$sr_replace = array(pmpro_implodeToEnglish($post_membership_levels_names), esc_url(site_url($_SERVER['REQUEST_URI'])));
 		//get the correct message to show at the bottom
 		if($current_user->ID) {
 			//not a member
@@ -266,7 +266,7 @@ function pmpro_events_events_manager_requires_membership_columns_content( $colum
 			}
 		}
 		if ( ! empty( $protected_levels ) ) {
-			echo implode( ', ', $protected_levels);
+			echo wp_kses_post( implode( ', ', $protected_levels) );
 		} else {
 			echo '&mdash;';
 		}

--- a/modules/the-events-calendar.php
+++ b/modules/the-events-calendar.php
@@ -186,7 +186,7 @@ function pmpro_events_tribe_events_requires_membership_columns_content( $column_
 			}
 		}
 		if ( ! empty( $protected_levels ) ) {
-			echo implode( ', ', $protected_levels);
+			echo wp_kses_post( implode( ', ', $protected_levels) );
 		} else {
 			echo '&mdash;';
 		}

--- a/pmpro-events.php
+++ b/pmpro-events.php
@@ -1,11 +1,12 @@
 <?php
 /*
-Plugin Name: Paid Memberships Pro - Events Add On
+Plugin Name: PMPro Events
 Plugin URI: https://www.paidmembershipspro.com/add-ons/events-for-members-only/
 Description: Offer Members-only events using PMPro and popular events plugins.
 Version: 1.0
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com
+Text Domain: pmpro-events
 */
 
 define( 'PMPRO_EVENTS_BASENAME', plugin_basename( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Paid Memberships Pro - Events Add On ===
+=== PMPro Events ===
 Contributors: strangerstudios
 Tags: paid memberships pro, events, events calendar, events manager, bookings, calendar, registration, tribe
 Requires at least: 3.5


### PR DESCRIPTION
Getting the plugin ready for wp.org submission.

Temporarily change the name to pmpro events so that the .org URL will be /pmpro-events.