### PR TITLE
Add membership to recurring event posts

### DIFF
--- a/modules/events-manager.php
+++ b/modules/events-manager.php
@@ -258,3 +258,56 @@ function pmpro_events_events_manager_requires_membership_columns_content( $colum
 }
 add_filter( 'manage_event_posts_columns', 'pmpro_events_events_manager_requires_membership_columns_head' );
 add_action( 'manage_event_posts_custom_column', 'pmpro_events_events_manager_requires_membership_columns_content', 10, 2 );
+
+/**
+ * Apply membership requirements to recurring event posts.
+ *
+ * @param bool      $save_ok   Save OK?
+ * @param \EM_Event $event     Event
+ * @param array     $event_ids Event IDs
+ * @param array     $post_ids  Post IDs
+ * @return bool     $save_ok
+ */
+function pmpro_events_events_manager_em_event_save_events($save_ok, $event, $event_ids, $post_ids) {
+	global $wpdb;
+
+	if ( empty ( $event->post_id ) ) {
+		return $save_ok;
+	}
+
+	// fetch membership requirements for main event entry
+	$membership_requirements = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT * FROM {$wpdb->pmpro_memberships_pages} WHERE page_id = %s",
+			$event->post_id
+		)
+	);
+	if ( empty( $membership_requirements ) ) {
+		return $save_ok;
+	}
+
+	// remove all memberships for the individual event posts
+	$deletion_query = sprintf(
+		"DELETE FROM {$wpdb->pmpro_memberships_pages} WHERE page_id IN (%s)",
+		implode( ",", $post_ids )
+	);
+	$wpdb->query( $deletion_query );
+
+	// prepare a bulk insert since we may have up to hundreds of recurring events
+	$inserts = array();
+	foreach( $post_ids as $event_post_id ) {
+		foreach( $membership_requirements as $membership_requirement ) {
+			$inserts[] = $wpdb->prepare(
+				"('%s', '%s')",
+				intval( $membership_requirement->membership_id ),
+				intval( $event_post_id )
+			);
+		}
+	}
+
+	$inserts_sql = "INSERT INTO {$wpdb->pmpro_memberships_pages} (membership_id, page_id) VALUES " . implode( ',', $inserts );
+	$wpdb->query( $inserts_sql );
+
+	return $save_ok;
+}
+add_filter( 'em_event_save_events', 'pmpro_events_events_manager_em_event_save_events', 10, 4 );


### PR DESCRIPTION
We were missing membership information in the recurring event posts
because the additional events are added to the database directly after
the main event post is created.

Events Manager tries to cater for main event post meta and copies it over
in EM_Event_Recurring_Post_Admin's save_post method which copies over all meta
from the original post.
We don't use meta for storing membership requirements so that doesn't help us.

Our pmpro_page_save hook never kicked in because the recurring event posts are added
as direct SQL queries in EM_Event::save_events().

This commit fixes by hooking into the em_event_save_events filter which is called at
the end of the save_events() function's run.
The filter returns the event, post_ids and event_ids, and so we are able to get the main post,
find its membership requirements (if any) from the pmpro_memberships_pages table,
and duplicate them as appropriate to each of the child events.