### PR TITLE
Assign a value of null after unsetting an event

### DIFF
--- a/modules/events-manager.php
+++ b/modules/events-manager.php
@@ -215,6 +215,7 @@ function pmpro_events_events_manager_filter_calendar_page( $event ) {
 		// Filter events from calendar page if the member doesn't meet the requirements.
 		if ( ! pmpro_has_membership_access( $event['post_id'] ) && ! empty( $filterqueries ) ) {
 			unset( $event );
+			$event = null;
 		}
 	}
 	


### PR DESCRIPTION
This fixes a crash which occurs when a member views a calendar
with events that are not available for their membership level.

$event will be unset and the function fails when it tries to return a variable that has been unset.