### PR TITLE
General enhancements/bug fixes for Sugar Calendar.

### DIFF
--- a/modules/sugar-calendar.php
+++ b/modules/sugar-calendar.php
@@ -17,9 +17,12 @@ add_action( 'admin_menu', 'pmpro_events_sugar_calendar_page_meta_wrapper' );
  * Filters on https://www.paidmembershipspro.com/hook/pmpro_has_membership_access_filter/
  */
 function pmpro_events_sugar_calendar_has_membership_access( $hasaccess, $post, $user, $levels ) {
-	
+
 	if ( $post->post_type == 'sc_event' && ! $hasaccess ) {
-		remove_action( 'sc_before_event_content', 'sc_add_event_details' );
+		// Filter to show event details to non-members for restricted events.
+		if ( apply_filters( 'pmpro_events_sc_hide_event_meta', true ) ) {
+			remove_action( 'sc_before_event_content', 'sc_add_event_details' );
+		}
 	}
 
 	return $hasaccess;
@@ -31,7 +34,12 @@ add_filter( 'pmpro_has_membership_access_filter', 'pmpro_events_sugar_calendar_h
  * @since 1.0
  */
 function pmpro_events_sc_filter_events_archive( $events ) {
+
 	if ( ! function_exists( 'pmpro_has_membership_access' ) ) {
+		return $events;
+	}
+
+	if ( is_admin() || is_single() ) {
 		return $events;
 	}
 


### PR DESCRIPTION
* ENHANCEMENT: Filter added to show/hide event meta for non-members for Sugar Calendar. `pmpro_events_sc_hide_event_meta` (Hidden by default - accepts boolean values).

* Bug Fix: Calendar in admin would hide events if admin didn't have an active membership level and advanced settings was hiding posts in archives for non-members.