### PR TITLE
TEC > Pass the current $post object to get_the_excerpt fallback when overriding TEC event excerpts

### DIFF
--- a/modules/the-events-calendar.php
+++ b/modules/the-events-calendar.php
@@ -155,9 +155,9 @@ function pmpro_events_tribe_events_excerpt_filter( $excerpt, $post ) {
 	$showexcerpts = apply_filters( 'pmpro_events_tribe_events_show_excerpts', pmpro_getOption( "showexcerpts" ), $post );
 
 	if ( pmpro_has_membership_access( $post->ID ) ) {
-		$excerpt = get_the_excerpt();
+		$excerpt = get_the_excerpt( $post );
 	} elseif ( $showexcerpts && !pmpro_has_membership_access( $post->ID ) ) {
-		$excerpt = get_the_excerpt();
+		$excerpt = get_the_excerpt( $post );
 	} else {
 		$excerpt = '';
 	}


### PR DESCRIPTION
This PR fixes #39

It addresses a problem where the same excerpt would be used on every event excerpt when in the calendar list view for TEC events.

Tested and confirmed as fixed on a customer who ran into this issue separate from #39.