### PR TITLE
Sugar Calendar > Disable Event Ticketing box on singular event if protected

### DIFF
--- a/modules/sugar-calendar.php
+++ b/modules/sugar-calendar.php
@@ -21,7 +21,11 @@ function pmpro_events_sugar_calendar_has_membership_access( $hasaccess, $post, $
 	if ( $post->post_type == 'sc_event' && ! $hasaccess ) {
 		// Filter to show event details to non-members for restricted events.
 		if ( apply_filters( 'pmpro_events_sc_hide_event_meta', true ) ) {
+			// Remove the event details.
 			remove_action( 'sc_before_event_content', 'sc_add_event_details' );
+
+			// Remove the ticketing.
+			remove_action( 'sc_after_event_content', 'Sugar_Calendar\AddOn\Ticketing\Frontend\Single\display' );
 		}
 	}
 


### PR DESCRIPTION
This PR extends the Sugar Calendar integration by further integrating with the [Event Ticketing](https://sugarcalendar.com/downloads/event-tickets/) add-on for Sugar Calendar.

The code will disable the Event Ticketing box on singular event if that event is protected.

How it looks without this change:
![image](https://user-images.githubusercontent.com/709662/122787764-44157780-d27b-11eb-8f7e-19e99e620801.png)

How it looks after this change has been included:
![image](https://user-images.githubusercontent.com/709662/122787792-4c6db280-d27b-11eb-8cc0-dcb4bf287754.png)
