### PR TITLE
Improving no-access message for PMPro 3.1

### DIFF
--- a/pmpro-events.php
+++ b/pmpro-events.php
@@ -67,11 +67,11 @@ function pmpro_events_no_access_message_body( $body, $level_ids ) {
 
 	// Generate the message for the event.
 	if ( count( $level_ids ) !== 1 ) {
-		$body = '<p>' . __(' You must be a member to access this event.', 'pmpro-events') . '</p>';
-		$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'pmpro-events' ) . '</a></p>';
+		$body = '<p>' . esc_html__(' You must be a member to access this event.', 'pmpro-events') . '</p>';
+		$body .= '<p><a class="' . esc_attr( pmpro_get_element_class( 'pmpro_btn' ) ) . '" href="!!levels_page_url!!">' . esc_html__( 'View Membership Levels', 'pmpro-events' ) . '</a></p>';
 	} else {
-		$body = '<p>' . __(' You must be a !!levels!! member to access this event.', 'pmpro-events') . '</p>';
-		$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'pmpro-events' ) . '</a></p>';
+		$body = '<p>' . esc_html__(' You must be a !!levels!! member to access this event.', 'pmpro-events') . '</p>';
+		$body .= '<p><a class="' . esc_attr( pmpro_get_element_class( 'pmpro_btn' ) ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . esc_html__( 'Join Now', 'pmpro-events' ) . '</a></p>';
 	}
 
 	return $body;

--- a/pmpro-events.php
+++ b/pmpro-events.php
@@ -114,13 +114,13 @@ function pmpro_events_activation_admin_notice() {
 		if (  ! defined( 'EM_VERSION' ) && ! class_exists( 'Tribe__Events__Main' ) && ! defined( 'AI1EC_PATH' ) && ! class_exists( 'Sugar_Calendar\\Plugin' ) ) {
 		?>
 			<div class="notice notice-warning is-dismissible">
-			<p><?php printf( __( "Thank you for activating the Events Add On for Paid Memberships Pro. Unfortunately it seems we weren't able to find any supported events plugin. <a href='%s' target='_blank'>For more information click here.</a>", 'pmpro-events' ), "https://www.paidmembershipspro.com/add-ons/events-for-members-only/" ); ?></p>
+			<p><?php echo wp_kses_post( sprintf( __( "Thank you for activating the Events Add On for Paid Memberships Pro. Unfortunately it seems we weren't able to find any supported events plugin. <a href='%s' target='_blank'>For more information click here.</a>", 'pmpro-events' ), "https://www.paidmembershipspro.com/add-ons/events-for-members-only/" ) ); ?></p>
 		</div>
 		<?php
 		}else{
 		?>
 		<div class="updated notice is-dismissible">
-			<p><?php printf( __( 'Thank you for activating the Events Add On for Paid Memberships Pro. To get started, edit an event and look for the "Require Membership" box in the sidebar. <a href="%s">View more documentation here.</a>', 'pmpro-events' ), "https://www.paidmembershipspro.com/add-ons/events-for-members-only/" ); ?></p>
+			<p><?php echo wp_kses_post( sprintf( __( 'Thank you for activating the Events Add On for Paid Memberships Pro. To get started, edit an event and look for the "Require Membership" box in the sidebar. <a href="%s">View more documentation here.</a>', 'pmpro-events' ), "https://www.paidmembershipspro.com/add-ons/events-for-members-only/" ) ); ?></p>
 		</div>
 		<?php
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Uses new 3.1 filters/UI
- Avoids calling deprecated filters

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
