### PR TITLE
Resolve PHP warning for Events Manager

### DIFF
--- a/modules/events-manager.php
+++ b/modules/events-manager.php
@@ -69,17 +69,17 @@ add_action( 'em_event_output', 'pmpro_events_events_manager_em_event_output', 1,
  */
 function pmpro_events_events_manager_output_placeholder( $replace, $EM_Event, $result ) {
 	global $wp_query, $wp_rewrite, $post, $current_user;
-	if( function_exists( 'pmpro_hasMembershipLevel' ) && !pmpro_has_membership_access( $post->post_id ) ) {
-		$hasaccess = pmpro_has_membership_access($post->post_id, NULL, true);		
-		if(is_array($hasaccess)) {
+	if ( function_exists( 'pmpro_hasMembershipLevel' ) && ! pmpro_has_membership_access( $EM_Event->post_id ) ) {
+		$hasaccess = pmpro_has_membership_access( $EM_Event->post_id, NULL, true );
+		if ( is_array( $hasaccess ) ) {
 			//returned an array to give us the membership level values
 			$post_membership_levels_ids = $hasaccess[1];
 			$post_membership_levels_names = $hasaccess[2];
 			$hasaccess = $hasaccess[0];
 		}
-		switch( $result ) {
+		switch ( $result ) {
 			case '#_BOOKINGFORM':
-				if(empty($hasaccess)) {
+				if ( empty( $hasaccess ) ) {
 					$replace = '';	
 					break;	
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Getting the post ID from the filter arguments where it's always set.
Some WPCS changes.

Resolves #55

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Resolve a PHP warning for Events Manager that occurs when event content is retrieved via AJAX 
